### PR TITLE
Improving group mode

### DIFF
--- a/NotificationNotes.iml
+++ b/NotificationNotes.iml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="NotificationNotes" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="NotificationNotes"
+	external.linked.project.path="$MODULE_DIR$"
+	external.root.project.path="$MODULE_DIR$"
+	external.system.id="GRADLE"
+	external.system.module.group=""
+	external.system.module.version="unspecified"
+	type="JAVA_MODULE"
+	version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
@@ -8,12 +15,14 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+  <component name="NewModuleRootManager"
+	     LANGUAGE_LEVEL="JDK_1_7"
+	     inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/NotificationNotes.iml
+++ b/NotificationNotes.iml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="NotificationNotes"
-	external.linked.project.path="$MODULE_DIR$"
-	external.root.project.path="$MODULE_DIR$"
-	external.system.id="GRADLE"
-	external.system.module.group=""
-	external.system.module.version="unspecified"
-	type="JAVA_MODULE"
-	version="4">
+<module external.linked.project.id="NotificationNotes" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
@@ -15,14 +8,12 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager"
-	     LANGUAGE_LEVEL="JDK_1_7"
-	     inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/app/src/main/java/com/khuttun/notificationnotes/NotesListAdapter.java
+++ b/app/src/main/java/com/khuttun/notificationnotes/NotesListAdapter.java
@@ -202,6 +202,7 @@ class NotesListAdapter
         if (PreferenceManager.getDefaultSharedPreferences(this.context).getBoolean(this.context
                 .getString(R.string.group_notif_pref_key), false))
         {
+            this.notificationMgr.checkNotification(n);
             this.notificationMgr.setGroupNotification(this.notes);
         }
         else

--- a/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
+++ b/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
@@ -23,10 +23,12 @@ public class NotificationMgr
 {
     private static final String CHANNEL_ID = "notes";
     private static final int GROUP_NOTIF_ID = -1000;
-
+    private static  final  int SUMMARY_NOTIF_ID = -2000;
+    private static final String GROUP_KEY = "com.khuttun.notificationnotes";
     private Context context;
     private NotificationManager notificationManager;
-    private NotificationCompat.Builder notificationBuilder;
+    // private NotificationCompat.Builder notificationBuilder;
+    private boolean groupAPI = false;
 
     public NotificationMgr(Context context)
     {
@@ -42,14 +44,23 @@ public class NotificationMgr
                     NotificationManager.IMPORTANCE_LOW));
         }
 
-        this.notificationBuilder = new NotificationCompat.Builder(this.context, CHANNEL_ID);
-        this.notificationBuilder.setSmallIcon(R.drawable.pen);
-        this.notificationBuilder.setOngoing(true);
-        this.notificationBuilder.setPriority(NotificationCompat.PRIORITY_LOW);
-        this.notificationBuilder.setContentIntent(PendingIntent
-                .getActivity(this.context, 0, new Intent(this.context, MainActivity.class), 0));
+        // Grouping notifications together so they are expandable is available on Nougat and newer
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        {
+            this.groupAPI = true;
+        }
     }
 
+    public NotificationCompat.Builder getNotificationBuilder()
+    {
+        NotificationCompat.Builder Builder = new NotificationCompat.Builder(this.context, CHANNEL_ID);
+        Builder.setSmallIcon(R.drawable.pen);
+        Builder.setOngoing(true);
+        Builder.setPriority(NotificationCompat.PRIORITY_LOW);
+        Builder.setContentIntent(PendingIntent
+                .getActivity(this.context, 0, new Intent(this.context, MainActivity.class), 0));
+        return Builder;
+    }
     public void setNotification(NotificationNote note)
     {
         if (Globals.LOG) Log.d(Globals.TAG, "Notification: ID " + note.id + ", show " + note.isVisible);
@@ -65,20 +76,13 @@ public class NotificationMgr
 
     public void setGroupNotification(ArrayList<NotificationNote> notes)
     {
-        ArrayList<NotificationNote> visibleNotes = new ArrayList<>();
-        for (int i = 0; i < notes.size(); ++i)
-        {
-            NotificationNote n = notes.get(i);
-            if (n.isVisible)
-            {
-                visibleNotes.add(n);
-            }
-        }
-
+        ArrayList<NotificationNote> visibleNotes = getVisibleNotes(notes);
         if (Globals.LOG) Log.d(Globals.TAG, "Group notification: visible notes " + visibleNotes.size());
+
 
         switch (visibleNotes.size())
         {
+
             case 0:
                 this.notificationManager.cancel(GROUP_NOTIF_ID);
                 break;
@@ -90,9 +94,52 @@ public class NotificationMgr
                 break;
 
             default:
-                this.notificationManager.notify(GROUP_NOTIF_ID, createGroupNotification(visibleNotes));
+                if (groupAPI)
+                {
+                    ArrayList<Notification> groupedNotes = createGroupNotifications(visibleNotes);
+                    for (int i = 0; i < groupedNotes.size(); i++)
+                    {
+                        Notification note = groupedNotes.get(i);
+                        String title = note.extras.getString("android.title");
+                        String text = note.extras.getString("android.text");
+                        int id = i == groupedNotes.size()-1 ?
+                                SUMMARY_NOTIF_ID : findNotification(notes, title, text);
+                        this.notificationManager.notify("note", id, note);
+                    }
+                }
+                else
+                {
+                    this.notificationManager.notify(GROUP_NOTIF_ID,
+                            createLegacyGroupNotification(visibleNotes));
+                }
                 break;
         }
+    }
+
+    private int findNotification(ArrayList<NotificationNote> notes, String title, String text)
+    {
+        for (int j = 0; j < notes.size(); j++)
+        {
+            NotificationNote note = notes.get(j);
+            if (note.text == text && note.title == title)
+            {
+                return note.id;
+            }
+        }
+        return -1;
+    }
+
+    private ArrayList<NotificationNote> getVisibleNotes(ArrayList<NotificationNote> notes) {
+        ArrayList<NotificationNote> visibleNotes = new ArrayList<>();
+        for (int i = 0; i < notes.size(); i++)
+        {
+            NotificationNote n = notes.get(i);
+            if (n.isVisible)
+            {
+                visibleNotes.add(n);
+            }
+        }
+        return visibleNotes;
     }
 
     public void clearAllNotifications()
@@ -101,27 +148,33 @@ public class NotificationMgr
         this.notificationManager.cancelAll();
     }
 
+
     private Notification createNotification(String title, String text)
     {
-        this.notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(text));
-        this.notificationBuilder.setContentTitle(title);
-        this.notificationBuilder.setContentText(text);
-        return this.notificationBuilder.build();
+        NotificationCompat.Builder notificationBuilder = getNotificationBuilder();
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(text));
+        notificationBuilder.setContentTitle(title);
+        notificationBuilder.setContentText(text);
+        return notificationBuilder.build();
     }
 
-    private Notification createGroupNotification(ArrayList<NotificationNote> notes)
+
+    // Used for Android versions below Nougat (7.0)
+    private Notification createLegacyGroupNotification(ArrayList<NotificationNote> notes)
     {
+        NotificationCompat.Builder notificationBuilder = getNotificationBuilder();
         NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle();
         for (int i = 0; i < notes.size(); ++i)
         {
             style.addLine(getGroupNotificationLine(notes.get(i)));
         }
-        this.notificationBuilder.setStyle(style);
-        this.notificationBuilder.setContentTitle(
+        notificationBuilder.setStyle(style);
+        notificationBuilder.setContentTitle(
                 this.context.getString(R.string.group_notif_title) + ": " + notes.size());
-        this.notificationBuilder.setContentText(getGroupNotificationLine(notes.get(0)));
-        return this.notificationBuilder.build();
+        notificationBuilder.setContentText(getGroupNotificationLine(notes.get(0)));
+        return notificationBuilder.build();
     }
+
 
     private CharSequence getGroupNotificationLine(NotificationNote note)
     {
@@ -129,4 +182,43 @@ public class NotificationMgr
         sp.setSpan(new StyleSpan(Typeface.BOLD), 0, note.title.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         return sp;
     }
+
+    // Used for Android Nougat (7.0) and above
+    private ArrayList<Notification> createGroupNotifications(ArrayList<NotificationNote> notes) {
+
+        ArrayList<Notification> groupedNotes = new ArrayList<Notification>();
+        for (int i = 0; i < notes.size(); ++i)
+        {
+            NotificationNote note = notes.get(i);
+            Notification newNote = createGroupNotification(note.title, note.text);
+            groupedNotes.add(newNote);
+        }
+        Notification summary = createSummaryNotification(notes.size());
+        groupedNotes.add(summary);
+        return groupedNotes;
+    }
+
+    private Notification createGroupNotification(String title, String text)
+    {
+        NotificationCompat.Builder notificationBuilder = getNotificationBuilder();
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(text));
+        notificationBuilder.setContentTitle(title);
+        notificationBuilder.setContentText(text);
+        notificationBuilder.setGroup(this.GROUP_KEY);
+        notificationBuilder.setGroupSummary(false);
+        return notificationBuilder.build();
+    }
+
+    private Notification createSummaryNotification(int size)
+    {
+        String message = this.context.getString(R.string.group_notif_title) + ": " + size;
+        NotificationCompat.Builder notificationBuilder = getNotificationBuilder();
+        notificationBuilder.setStyle(new NotificationCompat.InboxStyle());
+        notificationBuilder.setContentTitle(message);
+        notificationBuilder.setContentText(message);
+        notificationBuilder.setGroup(this.GROUP_KEY);
+        notificationBuilder.setGroupSummary(true);
+        return notificationBuilder.build();
+    }
 }
+

--- a/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
+++ b/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
@@ -85,26 +85,34 @@ public class NotificationMgr
                 break;
 
             default:
-                ArrayList<Notification> groupedNotes = createGroupNotifications(visibleNotes);
-                for (int i = 0; i < groupedNotes.size(); i++)
+                if (groupAPI)
                 {
-                    Notification note = groupedNotes.get(i);
-                    String title = note.extras.getString("android.title");
-                    String text = note.extras.getString("android.text");
-                    int id = -1;
-                    if (i == groupedNotes.size() - 1)
+                    ArrayList<Notification> groupedNotes = createGroupNotifications(visibleNotes);
+                    for (int i = 0; i < groupedNotes.size(); i++)
                     {
-                        id = SUMMARY_NOTIF_ID;
+                        Notification note = groupedNotes.get(i);
+                        String title = note.extras.getString("android.title");
+                        String text = note.extras.getString("android.text");
+                        int id = -1;
+                        if (i == groupedNotes.size() - 1)
+                        {
+                            id = SUMMARY_NOTIF_ID;
+                        }
+                        else if (i == 0)
+                        {
+                            id = GROUP_NOTIF_ID;
+                        }
+                        else
+                        {
+                            id = findNotificationID(notes, title, text);
+                        }
+                        this.notificationManager.notify("note", id, note);
                     }
-                    else if (i == 0)
-                    {
-                        id = GROUP_NOTIF_ID;
-                    }
-                    else
-                    {
-                        id = findNotificationID(notes, title, text);
-                    }
-                    this.notificationManager.notify("note", id, note);
+                }
+                else
+                {
+                    this.notificationManager.notify("note", SUMMARY_NOTIF_ID,
+                            createSummaryNotification(visibleNotes));
                 }
                 break;
         }
@@ -156,7 +164,7 @@ public class NotificationMgr
 
     /**
      * Creates a notification with the number of notes and the first line of each note.
-     * Used for Android versions below Nougat (7.0).
+     * Visible for Android versions below Nougat (7.0).
      * Is required for Android versions Nougat and beyond, but does not show.
      */
     private Notification createSummaryNotification(ArrayList<NotificationNote> notes)

--- a/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
+++ b/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
@@ -1,8 +1,6 @@
 package com.khuttun.notificationnotes;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -24,11 +22,10 @@ public class NotificationMgr
 {
     private static final String CHANNEL_ID = "notes";
     private static final int GROUP_NOTIF_ID = -1000;
-    private static  final  int SUMMARY_NOTIF_ID = -2000;
+    private static final int SUMMARY_NOTIF_ID = -2000;
     private static final String GROUP_KEY = "com.khuttun.notificationnotes";
     private Context context;
     private NotificationManagerCompat notificationManager;
-    // private NotificationCompat.Builder notificationBuilder;
     private boolean groupAPI = false;
 
     public NotificationMgr(Context context)
@@ -57,6 +54,7 @@ public class NotificationMgr
     public void setNotification(NotificationNote note)
     {
         if (Globals.LOG) Log.d(Globals.TAG, "Notification: ID " + note.id + ", show " + note.isVisible);
+
         if (note.isVisible)
         {
             this.notificationManager.notify(note.id, createNotification(note.title, note.text));
@@ -76,7 +74,6 @@ public class NotificationMgr
 
         switch (visibleNotes.size())
         {
-
             case 0:
                 this.notificationManager.cancel(GROUP_NOTIF_ID);
                 break;
@@ -95,15 +92,17 @@ public class NotificationMgr
                     String title = note.extras.getString("android.title");
                     String text = note.extras.getString("android.text");
                     int id = -1;
-                    if (i == groupedNotes.size()-1)
+                    if (i == groupedNotes.size() - 1)
                     {
-                       id = SUMMARY_NOTIF_ID;
-                    } else if (i == 0)
+                        id = SUMMARY_NOTIF_ID;
+                    }
+                    else if (i == 0)
                     {
                         id = GROUP_NOTIF_ID;
-                    } else
+                    }
+                    else
                     {
-                        id = findNotification(notes, title, text);
+                        id = findNotificationID(notes, title, text);
                     }
                     this.notificationManager.notify("note", id, note);
                 }
@@ -111,7 +110,7 @@ public class NotificationMgr
         }
     }
 
-    private int findNotification(ArrayList<NotificationNote> notes, String title, String text)
+    private int findNotificationID(ArrayList<NotificationNote> notes, String title, String text)
     {
         for (int j = 0; j < notes.size(); j++)
         {
@@ -124,7 +123,8 @@ public class NotificationMgr
         return -1;
     }
 
-    private ArrayList<NotificationNote> getVisibleNotes(ArrayList<NotificationNote> notes) {
+    private ArrayList<NotificationNote> getVisibleNotes(ArrayList<NotificationNote> notes)
+    {
         ArrayList<NotificationNote> visibleNotes = new ArrayList<>();
         for (int i = 0; i < notes.size(); i++)
         {
@@ -154,8 +154,12 @@ public class NotificationMgr
     }
 
 
-    // Used for Android versions below Nougat (7.0)
-    private Notification createLegacyGroupNotification(ArrayList<NotificationNote> notes)
+    /**
+     * Creates a notification with the number of notes and the first line of each note.
+     * Used for Android versions below Nougat (7.0).
+     * Is required for Android versions Nougat and beyond, but does not show.
+     */
+    private Notification createSummaryNotification(ArrayList<NotificationNote> notes)
     {
         NotificationCompat.Builder notificationBuilder = getNotificationBuilder();
         NotificationCompat.InboxStyle style = new NotificationCompat.InboxStyle();
@@ -180,10 +184,10 @@ public class NotificationMgr
         return sp;
     }
 
-    // Used for Android Nougat (7.0) and above
-    private ArrayList<Notification> createGroupNotifications(ArrayList<NotificationNote> notes) {
+    private ArrayList<Notification> createGroupNotifications(ArrayList<NotificationNote> notes)
+    {
         ArrayList<Notification> groupedNotes = new ArrayList<Notification>();
-        Notification summary = createLegacyGroupNotification(notes);
+        Notification summary = createSummaryNotification(notes);
         groupedNotes.add(summary);
         for (int i = 0; i < notes.size(); ++i)
         {
@@ -200,6 +204,9 @@ public class NotificationMgr
         return groupedNotes;
     }
 
+    /**
+     * Creates a notification that is the member of a group & is not the summary.
+     */
     private Notification createGroupNotification(String title, String text)
     {
         NotificationCompat.Builder notificationBuilder = getNotificationBuilder();
@@ -211,6 +218,9 @@ public class NotificationMgr
         return notificationBuilder.build();
     }
 
+    /**
+     * Creates a notification that shows how many notes there are.
+     */
     private Notification createTopNotification(int size)
     {
         String message = this.context.getString(R.string.group_notif_title) + ": " + size;

--- a/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
+++ b/app/src/main/java/com/khuttun/notificationnotes/NotificationMgr.java
@@ -61,6 +61,7 @@ public class NotificationMgr
                 .getActivity(this.context, 0, new Intent(this.context, MainActivity.class), 0));
         return Builder;
     }
+
     public void setNotification(NotificationNote note)
     {
         if (Globals.LOG) Log.d(Globals.TAG, "Notification: ID " + note.id + ", show " + note.isVisible);
@@ -76,6 +77,7 @@ public class NotificationMgr
 
     public void setGroupNotification(ArrayList<NotificationNote> notes)
     {
+        clearAllNotifications();
         ArrayList<NotificationNote> visibleNotes = getVisibleNotes(notes);
         if (Globals.LOG) Log.d(Globals.TAG, "Group notification: visible notes " + visibleNotes.size());
 


### PR DESCRIPTION
As of Android KitKat (7.0) the notes can be bundled together in a [group](https://developer.android.com/training/notify-user/group).  Each note within this group is expandable, and their full contents can be viewed.